### PR TITLE
scrapers and processers now work without ES

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -33,6 +33,7 @@ try:
         timeout=60
     )   # should be updated to reflect config
     elastic_index  = config.get("elasticsearch","document_index")
+    DATABASE_AVAILABLE = True
 
     # initialize mappings if index does not yet exist
     try:
@@ -46,6 +47,7 @@ try:
         raise Exception("Unable to communicate with elasticsearch, {}".format(e))
 except:
     logger.warning("No database functionality available")
+    DATABASE_AVAILABLE = False
 
 
 
@@ -58,6 +60,7 @@ def get_document(doc_id):
     return document
 
 def check_exists(document_id):
+    if not DATABASE_AVAILABLE: return False, {}
     index = elastic_index
     try:
         retrieved = client.get(elastic_index,document_id)
@@ -148,12 +151,6 @@ def insert_document(document, custom_identifier=''):
         except ConnectionTimeout:
             doc = {'_id':insert_document(document, custom_identifier)}
     else:
-        #
-        #print(elastic_index)
-        #print(document['doctype'])
-        #print(document)
-        #print(custom_identifier)
-        #
         try:
             doc = client.index(index=elastic_index, doc_type=document['doctype'], body=document, id=custom_identifier)
         except ConnectionTimeout:
@@ -325,7 +322,7 @@ def create_backup(name):
 
     Also note that the function returns before the backup process is completed.
     Avoid shutting down elasticsearch before the backup has been fully written
-    to disk. 
+    to disk.
 
     """
     body = {

--- a/core/document_class.py
+++ b/core/document_class.py
@@ -1,9 +1,9 @@
 '''
 This document class is the template for classes that add or update
 documents in the database. The scraper and update classes inherit
-from this class. 
+from this class.
 
-The basic functionality is adding meta-data 
+The basic functionality is adding meta-data
 
 '''
 
@@ -17,14 +17,14 @@ from core.database import insert_document, update_document, check_exists
 
 class Document(Task):
     '''
-    Documents reflect the basic format of documents in the datastore. 
-    On save attempts, this class tries to infer whether required fields 
-    are present. 
+    Documents reflect the basic format of documents in the datastore.
+    On save attempts, this class tries to infer whether required fields
+    are present.
 
-    The 'META' key contains a key:description of all other keys in the document. 
+    The 'META' key contains a key:description of all other keys in the document.
     '''
 
-    
+
 
     functiontype = '' # RSSscraper, text_processor, cluster_analysis, testing or other description of function
     version      = '' # string indicating version of function to track changes (e.g. "0.1")
@@ -36,10 +36,10 @@ class Document(Task):
         Call the task as either a local or distributed process
         '''
         if action == 'run':
-            self.run(*args, **kwargs)
+            return self.run(*args, **kwargs)
 
         if action == 'delay':
-            self.delay(*args, **kwargs)
+            return self.delay(*args, **kwargs)
 
 
     def __init__(self, database=True):
@@ -53,17 +53,17 @@ class Document(Task):
         Documents are saved to the general document collection
         defined in the core.database file.
 
-        Update existing documents by passing an elasticsearch results 
-        through the _update_document method. 
+        Update existing documents by passing an elasticsearch results
+        through the _update_document method.
 
         Note that by default, documents can only extend, not replace
-        old documents. 
+        old documents.
 
         '''
         assert self.doctype, "You need to declare a `self.doctype` in your subclass!"
         assert self.version, "You need to declare a `self.version` in your subclass!"
         assert self.functiontype, "You need to declare a `self.functiontype` in your subclass!"
-        
+
         document['doctype'] = self.doctype
         if '_id' in document.keys():
             custom_identifier = document.pop('_id')
@@ -83,11 +83,11 @@ class Document(Task):
         '''
         DO NOT OVERWRITE THIS METHOD
 
-        This method generates the metadata for returned documents based on 
+        This method generates the metadata for returned documents based on
         the 'get' function docstring and arguments.
 
-        All new keys are reflected in the 'META' key with the information 
-        about the script in question. 
+        All new keys are reflected in the 'META' key with the information
+        about the script in question.
 
         '''
         try:    docstring = self.get.__doc__
@@ -114,15 +114,15 @@ class Document(Task):
                 document['META'][key] = meta
 
         return document
-    
+
     def _verify(self, document):
         '''
         DO NOT OVERWRITE THIS METHOD
 
-        This method verifies whether yielded documents conform to the specification 
+        This method verifies whether yielded documents conform to the specification
         of the datastore
         '''
-        
+
         assert type(document)==dict
         assert document.get('META',False), "document lacks a `meta` key"
         for key in document.keys():
@@ -135,12 +135,12 @@ class Document(Task):
         '''
         DO NOT OVERWRITE THIS METHOD
 
-        This method checks whether the appropriate information is present in the subclass. 
+        This method checks whether the appropriate information is present in the subclass.
         '''
 
         for attribute in ['functiontype','version','date','doctype']:
             if not getattr(self,attribute):
-                logger.warning("""%s misses the appropriate `%s` property! 
+                logger.warning("""%s misses the appropriate `%s` property!
                 Please set these in the class __init__ method as self.%s""" %(
                     self.__class__, attribute,attribute))
 
@@ -150,7 +150,7 @@ class Document(Task):
         for method in ['process','get']:
             try:
                 if getattr(self,method).__doc__ in teststrings:
-                    logger.warning("""%s's %s docstring does not reflect functionality! 
+                    logger.warning("""%s's %s docstring does not reflect functionality!
                     Please update the docstring in your class definition.""" %(self.__class__, method))
             except:
                 pass

--- a/core/scraper_class.py
+++ b/core/scraper_class.py
@@ -1,8 +1,8 @@
 '''
 
-This file contains the class for scrapers. Each scraper should 
-inherit from this class and overwrite the 'get' function with 
-a generator. 
+This file contains the class for scrapers. Each scraper should
+inherit from this class and overwrite the 'get' function with
+a generator.
 
 Scrapers should yield dicts that contain the document (news article,
 tweet, blogpost, whatever)
@@ -22,24 +22,24 @@ language  : If you can safely assume the language of specified documents, please
 '''
 import logging
 from core.document_class import Document
-from core.database import check_exists
+from core.database import check_exists, DATABASE_AVAILABLE
 
 logger = logging.getLogger(__name__)
 
 class Scraper(Document):
     '''
-    Scrapers are the generic way of adding new documents to the datastore. 
-    
-    Make scrapers in the 'scrapers' folder by using <datasource>_scraper.py as 
-    the filename, containing a scraper which inherits from this class. 
-    
+    Scrapers are the generic way of adding new documents to the datastore.
+
+    Make scrapers in the 'scrapers' folder by using <datasource>_scraper.py as
+    the filename, containing a scraper which inherits from this class.
+
     the 'get' method should be a self-powered retrieval task, with optional
     arguments.
     '''
 
     functiontype = 'scraper'
     #language = ''
-        
+
     def __init__(self,database=True):
         Document.__init__(self,database)
 
@@ -54,7 +54,7 @@ class Scraper(Document):
     def sideload(self, doc, doctype, language):
         '''
         This function side-loads documents, basically setting scraper doctype, language
-        and metadata. 
+        and metadata.
 
         '''
         doc['doctype']  = self.doctype
@@ -62,16 +62,16 @@ class Scraper(Document):
         doc = self._add_metadata(doc)
         self._verify(doc)
         self._save_document(doc)
-        
+
     def run(self, *args, **kwargs):
         '''
         DO NOT OVERWRITE THIS METHOD
 
-        This is an internal function that calls the 'get' method and saves the 
-        resulting documents. 
+        This is an internal function that calls the 'get' method and saves the
+        resulting documents.
         '''
         logger.info("Started scraping")
-        if self.database == True:
+        if DATABASE_AVAILABLE == True:
             for doc in self.get(*args, **kwargs):
                 doc = self._add_metadata(doc)
                 self._verify(doc)
@@ -83,7 +83,7 @@ class Scraper(Document):
 
     def _test_function(self):
         '''tests whether a scraper works by seeing if it returns at least one document
-        
+
            GENERALLY DON'T OVERWRITE THIS METHOD!
         '''
         try:
@@ -93,7 +93,7 @@ class Scraper(Document):
                 return {"{self.__class__}".format(**locals()) :True}
         except:
             return {"{self.__class__}".format(**locals()) : False}
-        
+
     def _check_exists(self, *args, **kwargs):
         return check_exists(*args, **kwargs)
 

--- a/core/scraper_class.py
+++ b/core/scraper_class.py
@@ -71,7 +71,7 @@ class Scraper(Document):
         resulting documents.
         '''
         logger.info("Started scraping")
-        if DATABASE_AVAILABLE == True:
+        if DATABASE_AVAILABLE == True and kwargs.get('database',False):
             for doc in self.get(*args, **kwargs):
                 doc = self._add_metadata(doc)
                 self._verify(doc)

--- a/core/scraper_class.py
+++ b/core/scraper_class.py
@@ -71,7 +71,7 @@ class Scraper(Document):
         resulting documents.
         '''
         logger.info("Started scraping")
-        if DATABASE_AVAILABLE == True and kwargs.get('database',False):
+        if DATABASE_AVAILABLE == True and kwargs.get('database',True):
             for doc in self.get(*args, **kwargs):
                 doc = self._add_metadata(doc)
                 self._verify(doc)


### PR DESCRIPTION
Fixed INCA so that scrapers and processers now work when no elasticsearch instance is reachable (with warnings!). This should fix #48 

```python
>>> from inca import Inca
>>> client = Inca()
>>> testdocs = client.scrapers.testdocs()
>>> len(testdocs)
10
>>> processed_testdocs = [doc for doc in client.processing.lowercase(testdocs, field='text') if 'text_lowercase' in doc]
>>> len(processed_testdocs)
10
>>> client.database.list_doctypes()
WARNING:core.search_utils:Could not list documents: No database instance available
>>> client.database.doctype_first('testdocs')
WARNING:core.search_utils:Could not get first document: No database instance available
```