### PR TITLE
made delete_doctype compatible with ES5

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -138,7 +138,7 @@ def delete_document(document_id):
 
 def delete_doctype(doctype):
     '''Delete all documents of a given type'''
-    for doc in scroll_query({'filter':{'match':{'_type':doctype}}}):
+    for doc in scroll_query({'query':{'bool':{'filter':{'match':{'_type':doctype}}}}}):
         delete_document(doc['_id'])
     return True
 


### PR DESCRIPTION
quick bugfix to enable deletion of doctypes with ES5, but see also #250 for further issues