### PR TITLE
added functionality to repair broken records

### DIFF
--- a/processing/repair_processing.py
+++ b/processing/repair_processing.py
@@ -20,49 +20,28 @@ class reparse(Processer):
     by specifiying the new function to parse the content
     '''
 
-    def process(self, document,  source_field, parsefunction):
-        '''reparses {source_field}'''.format(**locals())
-        pass
-
-    def run(self, document, source_field, parsefunction, save=False):
+    def process(self, document_field, parsefunction,**kwargs):
         '''
         Takes a document and a parsing function and re-parses the HTML source.
 
         Parameters
         ---
-        document: dict or string
-            INCA-document that needs to be reparsed.
-            Either a dict with the full document or a string with the document id
-        source_field: string
-            key of the field that contains the HTML source
+        docuent_field: string
+            HTML source to be parsed
+
         parsefunction
             a Python function to parse the HTML source
-        save
-            whether the result should be returned or stored to the database
+
 
         Example
         ---
         p = inca.processing.repair_processing.reparse()
-        p.run('https://www.nu.nl/-/4959386/','htmlsource',inca.scrapers.news_scraper.nu.parsehtml)
+        p.run('https://www.nu.nl/-/4959386/','htmlsource',parsefunction=inca.scrapers.news_scraper.nu.parsehtml, save=True, Force=True)
     
         '''
 
-        if not (type(document) == dict and '_source' in document.keys()):
-
-            if check_exists(document):
-                document = get_document(document)
-            else:
-                logger.debug("document retrieval failure {document}".format(**locals()))
-                return document
-
-        newfields = parsefunction(self, document['_source'][source_field])
-        document['_source'].update(newfields)
-            
-        if save:
-            update_document(document, force=True)
-
-        else:
-            return document
+        newfields = parsefunction(self,htmlsource=document_field)
+        return newfields
 
 class redownload(Processer):
     '''
@@ -71,46 +50,23 @@ class redownload(Processer):
     by specifiying the new function to download the content
     '''
 
-    def process(self, document,  url_field, parsefunction):
-        '''re-downloads {url_field}'''.format(**locals())
-        pass
 
-    def run(self, document, url_field, html_field, downloadfunction, save=False):
+    def process(self, document_field, downloadfunction, **kwargs):
         '''
         Takes a document and a parsing function and re-parses the HTML source.
 
         Parameters
         ---
-        document: dict or string
-            INCA-document that needs to be reparsed.
-            Either a dict with the full document or a string with the document id
-        url_field: string
-            key of the field that contains the URL
-        html_field: string
-            key of the field in which to store the downloaded content 
+        docment_field: string
+            URL to be re-downloaded
         downloadfunction
             a Python function to download the URL
-        save
-            whether the result should be returned or stored to the database
 
         Example
         ---
         p = inca.processing.repair_processing.reparse()
-        p.run('https://www.nu.nl/-/4959386/','url','htmlsource',inca.scrapers.news_scraper.nu.get_page_body)
+        p.run('https://www.nu.nl/-/4959386/','url',downloadfunction=inca.scrapers.news_scraper.nu.get_page_body)
     
         '''
-
-        if not (type(document) == dict and '_source' in document.keys()):
-
-            if check_exists(document):
-                document = get_document(document)
-            else:
-                logger.debug("document retrieval failure {document}".format(**locals()))
-                return document
-
-        document['_source'][html_field] = downloadfunction(self, document['_source'][url_field])  
-        if save:
-            update_document(document, force=True)
-
-        else:
-            return document
+        newdownload = downloadfunction(self, document_field)        
+        return newdownload

--- a/processing/repair_processing.py
+++ b/processing/repair_processing.py
@@ -1,0 +1,116 @@
+'''
+This file contains functionality to repair errors in the database,
+for instance to re-parse the raw html source and/or to re-download
+the HTML source
+'''
+
+from core.processor_class import Processer
+from core.database import update_document, get_document, check_exists
+from dateutil import parser
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel('DEBUG')
+
+class reparse(Processer):
+    '''
+    Sometimes, content is not correctly parsed, because a scraped site
+    might have changed their layout. This allows to re-parse content
+    by specifiying the new function to parse the content
+    '''
+
+    def process(self, document,  source_field, parsefunction):
+        '''reparses {source_field}'''.format(**locals())
+        pass
+
+    def run(self, document, source_field, parsefunction, save=False):
+        '''
+        Takes a document and a parsing function and re-parses the HTML source.
+
+        Parameters
+        ---
+        document: dict or string
+            INCA-document that needs to be reparsed.
+            Either a dict with the full document or a string with the document id
+        source_field: string
+            key of the field that contains the HTML source
+        parsefunction
+            a Python function to parse the HTML source
+        save
+            whether the result should be returned or stored to the database
+
+        Example
+        ---
+        p = inca.processing.repair_processing.reparse()
+        p.run('https://www.nu.nl/-/4959386/','htmlsource',inca.scrapers.news_scraper.nu.parsehtml)
+    
+        '''
+
+        if not (type(document) == dict and '_source' in document.keys()):
+
+            if check_exists(document):
+                document = get_document(document)
+            else:
+                logger.debug("document retrieval failure {document}".format(**locals()))
+                return document
+
+        newfields = parsefunction(self, document['_source'][source_field])
+        document['_source'].update(newfields)
+            
+        if save:
+            update_document(document, force=True)
+
+        else:
+            return document
+
+class redownload(Processer):
+    '''
+    Sometimes, content is not correctly downloaded, for instance due to
+    a new cookie wall. This allows to re-download the content
+    by specifiying the new function to download the content
+    '''
+
+    def process(self, document,  url_field, parsefunction):
+        '''re-downloads {url_field}'''.format(**locals())
+        pass
+
+    def run(self, document, url_field, html_field, downloadfunction, save=False):
+        '''
+        Takes a document and a parsing function and re-parses the HTML source.
+
+        Parameters
+        ---
+        document: dict or string
+            INCA-document that needs to be reparsed.
+            Either a dict with the full document or a string with the document id
+        url_field: string
+            key of the field that contains the URL
+        html_field: string
+            key of the field in which to store the downloaded content 
+        downloadfunction
+            a Python function to download the URL
+        save
+            whether the result should be returned or stored to the database
+
+        Example
+        ---
+        p = inca.processing.repair_processing.reparse()
+        p.run('https://www.nu.nl/-/4959386/','url','htmlsource',inca.scrapers.news_scraper.nu.get_page_body)
+    
+        '''
+
+        if not (type(document) == dict and '_source' in document.keys()):
+
+            if check_exists(document):
+                document = get_document(document)
+            else:
+                logger.debug("document retrieval failure {document}".format(**locals()))
+                return document
+
+        document['_source'][html_field] = downloadfunction(self, document['_source'][url_field])  
+        if save:
+            update_document(document, force=True)
+
+        else:
+            return document


### PR DESCRIPTION
This new processor class provides functionality to repair records. Typical use-case: RSS-scrapers that are run over an existended period of time inevitably produce broken records, when the website changes, either due to layout changes (`parsehtml` produces incorrect output) or due to cookie walls etc (`get_page_source` fails to download the correct page content).

To repair these records, this processor provides two functionalities:

- re-downloading the html source of a given INCA-document
- parsing this source