### PR TITLE
ported legacy verify.py to processor

### DIFF
--- a/Requirements
+++ b/Requirements
@@ -7,6 +7,7 @@ billiard==3.3.0.23
 celery==3.1.23
 chardet==2.3.0
 coverage==4.1
+colorama
 cytoolz==0.8.0
 decorator==4.0.9
 elasticsearch==5.4.0

--- a/core/database.py
+++ b/core/database.py
@@ -352,14 +352,14 @@ def _remove_dots(document):
             document[k.replace('.','_')]= _remove_dots(v)
     return document
 
-def scroll_query(query,scroll_time='10m', log_interval=None):
+def scroll_query(query,scroll_time='30m', log_interval=None):
     """Scroll through the results of a query
 
     Parameters
     ----
     query : dict
         An elasticsearch query
-    scroll_time : string (default='10m')
+    scroll_time : string (default='30m')
         A string indicating the time-window to keep the results
         buffer active in elasticsearch. A small window risks timeouts, a high
         window risks running into resource ceilings in the database.

--- a/processing/annotate_processing.py
+++ b/processing/annotate_processing.py
@@ -12,34 +12,34 @@ logger = logging.getLogger(__name__)
 
 WINDOW=150
 
-def _annotate(text, key, question, highlight_regexp):
+def _annotate(text, key, question, highlight_regexp, display=True):
     '''prompts for annotation'''
-    print('\n',Fore.RED,'Please annotate the following text:')
-    if highlight_regexp == None:
-        print(Style.RESET_ALL,text)
-    else:
-        print(Fore.RED+'(only excerpts are shown)'+Style.RESET_ALL)
-        reststring = text
-        numberofmatches=len(re.findall(highlight_regexp,text))
-        poscount=0
-        for i in range(numberofmatches):
-            #print('Occurance {} of {}'.format(i+1,numberofmatches))
-            r=re.search(highlight_regexp,reststring)
-            print(poscount)
-            if poscount+r.start() < WINDOW:
-                print(text[poscount:poscount+r.start()], end='')
-                print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
-                print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+150])
-            else:
-                print(text[poscount+r.start()-WINDOW:poscount+r.start()], end='')
-                print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
-                print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+WINDOW])
-            reststring=reststring[r.end():]
-            poscount+=r.end()
-
-        answer=input(Fore.RED + question + Style.RESET_ALL)
-
-        return answer
+    if display == True:
+        print('\n',Fore.RED,'Please annotate the following text:')
+        if highlight_regexp == None:
+            print(Style.RESET_ALL,text)
+        else:
+            print(Fore.RED+'(only excerpts are shown)'+Style.RESET_ALL)
+            reststring = text
+            numberofmatches=len(re.findall(highlight_regexp,text))
+            poscount=0
+            for i in range(numberofmatches):
+                #print('Occurance {} of {}'.format(i+1,numberofmatches))
+                r=re.search(highlight_regexp,reststring)
+                print(poscount)
+                if poscount+r.start() < WINDOW:
+                    print(text[poscount:poscount+r.start()], end='')
+                    print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
+                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+150])
+                else:
+                    print(text[poscount+r.start()-WINDOW:poscount+r.start()], end='')
+                    print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
+                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+WINDOW])
+                reststring=reststring[r.end():]
+                poscount+=r.end()
+    
+    answer=input(Fore.RED + question + Style.RESET_ALL)
+    return answer
 
 
 class annotate(Processer):
@@ -50,8 +50,10 @@ class annotate(Processer):
 
         while True:
             annotations = {}
+            display=True
             for key, question in questions.items():
-                annotations[key] = _annotate(document_field,key,question, highlight_regexp)
+                annotations[key] = _annotate(document_field,key,question, highlight_regexp, display)
+                display=False
             print(Fore.RED+'You annotated this document as follows:'+Style.RESET_ALL)
             print(annotations)
             confirm = input(Fore.RED+'\nIs this correct? [Y/N]')

--- a/processing/annotate_processing.py
+++ b/processing/annotate_processing.py
@@ -10,9 +10,9 @@ init()
 
 logger = logging.getLogger(__name__)
 
-WINDOW=150
 
-def _annotate(text, key, question, highlight_regexp, display=True):
+
+def _annotate(text, key, question, highlight_regexp, window=150, display=True):
     '''prompts for annotation'''
     if display == True:
         print('\n',Fore.RED,'Please annotate the following text:')
@@ -27,14 +27,14 @@ def _annotate(text, key, question, highlight_regexp, display=True):
                 #print('Occurance {} of {}'.format(i+1,numberofmatches))
                 r=re.search(highlight_regexp,reststring)
                 print(poscount)
-                if poscount+r.start() < WINDOW:
+                if poscount+r.start() < window:
                     print(text[poscount:poscount+r.start()], end='')
                     print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
-                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+150])
+                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+window])
                 else:
-                    print(text[poscount+r.start()-WINDOW:poscount+r.start()], end='')
+                    print(text[poscount+r.start()-window:poscount+r.start()], end='')
                     print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
-                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+WINDOW])
+                    print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+window])
                 reststring=reststring[r.end():]
                 poscount+=r.end()
     
@@ -45,14 +45,14 @@ def _annotate(text, key, question, highlight_regexp, display=True):
 class annotate(Processer):
     '''Adds human annotations'''
 
-    def process(self, document_field, highlight_regexp = None, questions = {'relevance':'Is this relevant?'}):
+    def process(self, document_field, highlight_regexp = None, questions = {'relevance':'Is this relevant?'}, window=150):
         '''human annotations'''
 
         while True:
             annotations = {}
             display=True
             for key, question in questions.items():
-                annotations[key] = _annotate(document_field,key,question, highlight_regexp, display)
+                annotations[key] = _annotate(document_field,key,question, highlight_regexp, window=window, display=display)
                 display=False
             print(Fore.RED+'You annotated this document as follows:'+Style.RESET_ALL)
             print(annotations)

--- a/processing/annotate_processing.py
+++ b/processing/annotate_processing.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from core.processor_class import Processer
+import logging
+import re
+from colorama import init
+from colorama import Fore
+from colorama import Style
+
+init()
+
+logger = logging.getLogger(__name__)
+
+WINDOW=150
+
+def _annotate(text, key, question, highlight_regexp):
+    '''prompts for annotation'''
+    print('\n',Fore.RED,'Please annotate the following text:')
+    if highlight_regexp == None:
+        print(Style.RESET_ALL,text)
+    else:
+        print(Fore.RED+'(only excerpts are shown)'+Style.RESET_ALL)
+        reststring = text
+        numberofmatches=len(re.findall(highlight_regexp,text))
+        poscount=0
+        for i in range(numberofmatches):
+            #print('Occurance {} of {}'.format(i+1,numberofmatches))
+            r=re.search(highlight_regexp,reststring)
+            print(poscount)
+            if poscount+r.start() < WINDOW:
+                print(text[poscount:poscount+r.start()], end='')
+                print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
+                print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+150])
+            else:
+                print(text[poscount+r.start()-WINDOW:poscount+r.start()], end='')
+                print(Fore.GREEN+text[poscount+r.start():poscount+r.end()], end='')
+                print(Style.RESET_ALL + text[poscount+r.end():poscount+r.end()+WINDOW])
+            reststring=reststring[r.end():]
+            poscount+=r.end()
+
+        answer=input(Fore.RED + question + Style.RESET_ALL)
+
+        return answer
+
+
+class annotate(Processer):
+    '''Adds human annotations'''
+
+    def process(self, document_field, highlight_regexp = None, questions = {'relevance':'Is this relevant?'}):
+        '''human annotations'''
+
+        while True:
+            annotations = {}
+            for key, question in questions.items():
+                annotations[key] = _annotate(document_field,key,question, highlight_regexp)
+            print(Fore.RED+'You annotated this document as follows:'+Style.RESET_ALL)
+            print(annotations)
+            confirm = input(Fore.RED+'\nIs this correct? [Y/N]')
+            if confirm.strip().lower()=='y':
+                return annotations
+    


### PR DESCRIPTION
I ported the old verify.py so that it can be used as a processor within INCA and that it also accepts multiple questions to annotate.
Example usage (assuming an elasticsearch instance is running and there are at least some nu articles in the database):

```
from inca import Inca
myinca = Inca()

p = myinca.processing.annotate(docs_or_query='nu',field='text',highlight_regexp = 'hij',new_key='myproject', questions={'relevant':'Is dit relevant?'})

data = next(p)
```
(this annotates only one article and returns the result as a dict called data)