### PR TITLE
fixed error that stored only the last results insteaf of all (because…

### DIFF
--- a/inca/importers_exporters/json.py
+++ b/inca/importers_exporters/json.py
@@ -83,7 +83,7 @@ class export_json_file(Exporter):
             What compression to use when writing output file
         """
         self.extension = "json"
-        self.fileobj = self._makefile(destination, mode="w", compression=compression)
+        self.fileobj = self._makefile(destination, mode="a", compression=compression)
         for document in batch_of_documents:
             try:
                 doc_dump = json.dumps(document)


### PR DESCRIPTION
… file was overwritten each time a new bunch of documents arrived)

Fixes the error reported by our students.

Test case (just querying on a random frequently occuring word, 'dit'):

```In [2]: myinca = inca.Inca()
INFO:INCA:Providing verbose output

In [3]: myinca.importers_exporters.export_json_file('dit',destination='/Users/damian/downloads/test.json')

In [4]: myinca.importers_exporters.export_json_file(query = 'dit',destination='/Us
   ...: ers/damian/downloads/test.json')
INFO:INCA.core.search_utils:String input: searching for dit
INFO:INCA.core.search_utils:returning 0 of 212
INFO:INCA.core.search_utils:returning 100 of 212
INFO:INCA.core.search_utils:returning 200 of 212

In [5]:                                                                           
Do you really want to exit ([y]/n)? y
```

Then check how many lines the file has (should be same as results above (using bash):
```
damian$ wc -l '/Users/damian/downloads/test.json'
     212 /Users/damian/downloads/test.json
```