### PR TITLE
Fiximport2

### DIFF
--- a/inca/core/processor_class.py
+++ b/inca/core/processor_class.py
@@ -14,6 +14,7 @@ import logging
 from .document_class import Document
 from .database import get_document, update_document, check_exists, config, check_mapping
 # from . import *
+from inca import core
 
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')

--- a/inca/core/processor_class.py
+++ b/inca/core/processor_class.py
@@ -16,6 +16,8 @@ from .database import get_document, update_document, check_exists, config, check
 # from . import *
 from inca import core
 
+from collections import OrderedDict
+
 logger = logging.getLogger(__name__)
 logger.setLevel('DEBUG')
 
@@ -107,6 +109,8 @@ class Processer(Document):
             indicates whether the document should replace (true) or only
             expand existing documents (false). Note that partial updates
             are not supported when forcing.
+        extra_fields: list
+            (optional) list of fields that should be passed to the processor
         '''
 
         # 1. check if document or id --> return do
@@ -138,7 +142,13 @@ class Processer(Document):
                 document = document['_source']
             return document
         # 4. process document
-        document['_source'][new_key] = self.process(document['_source'][field], *args, **kwargs)
+        if 'extra_fields' in kwargs:
+            extra_fields = OrderedDict()
+            for fieldname in kwargs.pop('extra_fields'):
+                extra_fields[fieldname] = document['_source'][fieldname]
+            document['_source'][new_key] = self.process(document['_source'][field], *args, extra_fields = extra_fields, **kwargs)
+        else:
+            document['_source'][new_key] = self.process(document['_source'][field], *args, **kwargs)
         # 3. add metadata
         # document['_source'] = self._add_metadata(document['_source'])
         # 4. check metadata

--- a/inca/core/processor_class.py
+++ b/inca/core/processor_class.py
@@ -142,6 +142,7 @@ class Processer(Document):
                 document = document['_source']
             return document
         # 4. process document
+        # if extra_fields were supplied, then replace the list of field names with a dict containing their values
         if 'extra_fields' in kwargs:
             extra_fields = OrderedDict()
             for fieldname in kwargs.pop('extra_fields'):

--- a/inca/processing/annotate_processing.py
+++ b/inca/processing/annotate_processing.py
@@ -45,8 +45,12 @@ def _annotate(text, key, question, highlight_regexp, window=150, display=True):
 class annotate(Processer):
     '''Adds human annotations'''
 
-    def process(self, document_field, highlight_regexp = None, questions = {'relevance':'Is this relevant?'}, extra_filterquestion = False, window=150):
+    def process(self, document_field, highlight_regexp = None, questions = {'relevance':'Is this relevant?'}, extra_filterquestion = False, window=150, **kwargs):
         '''human annotations'''
+
+        if 'extra_fields' in kwargs:
+            for k,v in kwargs['extra_fields'].items():
+                print("{}:\t{}".format(k,v))
 
         while True:
             annotations = {}


### PR DESCRIPTION
- fixed one additional import problem
- changed processor class so that it supports passing multiple fields
- Made annotation-processor displaying additional info (e.g., titles).

Test case (given that the database at hand contains some documents matching the criteria):

```
from collections import OrderedDict
from inca import Inca
myinca = Inca()

questions=OrderedDict([('bron', 'Welke bron wordt geciteerd?'),
('frame_gen', 'Bevat dit artikel een genetisch predispositie frame?'),
('frame_ged','Bevat dit artikel een gedrag/levensstijlkeuzes frame?'),
('frame_socdet','Bevat dit artikel een sociale determinanten frame?'),
('relatiecode0','Bevat dit artikel relatiecode 0?'),
('relatiecode1','Bevat dit artikel relatiecode 1?'),
('relatiecode2','Bevat dit artikel relatiecode 2?'),
('relatiecode3','Bevat dit artikel relatiecode 3?'),
('relatiecode4','Bevat dit artikel relatiecode 4?'),
('relatiecode5','Bevat dit artikel relatiecode 5?'),
('relatiecode6','Bevat dit artikel relatiecode 6?'),
('leeftijdsgroep','Welke leeftijdsgroep wordt genoemd?'),
('positie_claim', 'Waar staat de claim?')])


p = myinca.processing.annotate(docs_or_query='doctype:nu AND (text:obesitas OR title:obesitas)',field='text',highlight_regexp = r'\bobesitas\b',new_key='myproject_obesitas', 
questions=questions, extra_filterquestion = True, window=20000, extra_fields=['title','doctype'])

next(p)


```