### PR TITLE
Csvheader

### DIFF
--- a/inca/importers_exporters/csv.py
+++ b/inca/importers_exporters/csv.py
@@ -122,8 +122,7 @@ class export_csv(Exporter):
             new = True
 
         writer = csv.DictWriter(outputfile, self.fields, extrasaction='ignore',*args, **kwargs)
-        if new:
-            writer.writeheader()
+        writer.writeheader()
         for doc in flat_batch:
             if remove_linebreaks:
                 doc = {k: v.replace('\n\r',' ').replace('\n',' ').replace('\'r',' ') for k,v in doc.items()}

--- a/inca/importers_exporters/csv.py
+++ b/inca/importers_exporters/csv.py
@@ -95,8 +95,6 @@ class export_csv(Exporter):
         args/kwargs are passed to csv.DictWriter.
         In particular, you might be interested in using the follwing arguments:
 
-        dialect='excel'
-            Ensures compatibility with Microsoft Excel
         delimiter=';'
             Use a semicolon instead of a comma. This is what Microsoft Excel
             expects in many locales (e.g., Dutch and German)


### PR DESCRIPTION
- Removed dialect='excel' in help file, because not compatible with European locales 
- Ensures output are always with headers