### PR TITLE
Fixgzip

### DIFF
--- a/inca/core/import_export_classes.py
+++ b/inca/core/import_export_classes.py
@@ -44,34 +44,12 @@ class BaseImportExport(Document):
             compression = self._detect_zip(filename)
         if not compression:
             return open(filename, mode=mode)
-
         else:
             filename += "." + compression
 
-        #if mode == 'r':
-        #    mode = 'rb'
-        #elif mode == 'a':
-        #    mode = 'ab'
-
-        #def cb(fileobj):
-        #    """monkey-patch fileobject write method to encode"""
-        #    original_write = fileobj.write
-        #    def write(input_string):
-        #        """write with encoding"""
-        #        bytes_string = input_string.encode()
-        #        original_write(bytes_string)
-        #    fileobj.write = write
-        #    return fileobj
-
-        # compressed formats requiring bytes-styleo pening below here
-
-        #if mode == 'w':
-        #    mode = 'wb'
         if compression == "gz":
-            #return cb(gzip.open(filename, mode=mode))
             return gzip.open(filename, mode=mode)
         if compression == "bz2":
-            #return cb(bz2.open(filename, mode=mode))
             return bz2.open(filename, mode=mode)
         return fileobj
 

--- a/inca/core/import_export_classes.py
+++ b/inca/core/import_export_classes.py
@@ -38,7 +38,7 @@ class BaseImportExport(Document):
 
 
     def open_file(self, filename, mode='r', force=False, compression="autodetect"):
-        if mode not in ["w","wb","a","ab"] and not os.path.exists(filename):
+        if mode not in ["w","wb","wt","a","ab","at"] and not os.path.exists(filename):
             logger.warning("File not found at {filename}".format(filename=filename))
         if compression == "autodetect":
             compression = self._detect_zip(filename)
@@ -48,27 +48,31 @@ class BaseImportExport(Document):
         else:
             filename += "." + compression
 
-        if mode == 'r':
-            mode = 'rb'
+        #if mode == 'r':
+        #    mode = 'rb'
+        #elif mode == 'a':
+        #    mode = 'ab'
 
-        def cb(fileobj):
-            """monkey-patch fileobject write method to encode"""
-            original_write = fileobj.write
-            def write(input_string):
-                """write with encoding"""
-                bytes_string = input_string.encode()
-                original_write(bytes_string)
-            fileobj.write = write
-            return fileobj
+        #def cb(fileobj):
+        #    """monkey-patch fileobject write method to encode"""
+        #    original_write = fileobj.write
+        #    def write(input_string):
+        #        """write with encoding"""
+        #        bytes_string = input_string.encode()
+        #        original_write(bytes_string)
+        #    fileobj.write = write
+        #    return fileobj
 
         # compressed formats requiring bytes-styleo pening below here
 
-        if mode == 'w':
-            mode = 'wb'
+        #if mode == 'w':
+        #    mode = 'wb'
         if compression == "gz":
-            return cb(gzip.open(filename, mode=mode))
+            #return cb(gzip.open(filename, mode=mode))
+            return gzip.open(filename, mode=mode)
         if compression == "bz2":
-            return cb(bz2.open(filename, mode=mode))
+            #return cb(bz2.open(filename, mode=mode))
+            return bz2.open(filename, mode=mode)
         return fileobj
 
     def open_dir(self, path,  mode='r', match=".*", force=False, compression="autodetect"):
@@ -278,7 +282,7 @@ class Exporter(BaseImportExport):
             self.processed += 1
             yield doc
 
-    def _makefile(self, filename, mode='w', force=False, compression=False):
+    def _makefile(self, filename, mode='wt', force=False, compression=False):
         filepath = os.path.dirname(filename)
         os.makedirs(filepath, exist_ok=True)
         # handle cases when a path instead of a filename is provided

--- a/inca/importers_exporters/json.py
+++ b/inca/importers_exporters/json.py
@@ -94,15 +94,9 @@ class export_json_file(Exporter):
                     document = document['_source']
                 document = {k:v for k, v in document.items() if not k=='META'}
             try:
-                #doc_dump = json.dumps(document)+'\n'
-                #if compression is None:
-                #    self.fileobj.write(doc_dump.encode())
-                #else:
-                #    self.fileobj.write(doc_dump)
                 doc_dump = json.dumps(document)
                 self.fileobj.write(doc_dump+'\n')
             except:
-                raise "hell"
                 self.failed += 1
                 self.failed_ids.append(document['_id'])
         if self.failed:
@@ -146,3 +140,6 @@ class export_json_files(Exporter):
                 self.failed +=1
                 self.failed_ids.append(document['_id'])
             fileobj.close()
+        if self.failed:
+            logger.warning("Failed to export {num} documents".format(num=self.failed))
+            logger.info("Failed ids: {ids}".format(ids=', '.join(self.failed_ids)))

--- a/inca/importers_exporters/json.py
+++ b/inca/importers_exporters/json.py
@@ -134,7 +134,7 @@ class export_json_files(Exporter):
         for document in batch_of_documents:
             filename = id2filename(document.get('_id'))
             location = os.path.join(destination,filename)
-            fileobj = self._makefile(location, mode='w', compression=compression)
+            fileobj = self._makefile(location, mode='wt', compression=compression)
             if include_meta==False:
                 if '_source' in document.keys():
                     document = document['_source']

--- a/inca/importers_exporters/json.py
+++ b/inca/importers_exporters/json.py
@@ -87,15 +87,20 @@ class export_json_file(Exporter):
             and META will be excluded.
         """
         self.extension = "json"
-        self.fileobj = self._makefile(destination, mode="a", compression=compression)
+        self.fileobj = self._makefile(destination, mode="at", compression=compression)
         for document in batch_of_documents:
             if include_meta==False:
                 if '_source' in document.keys():
                     document = document['_source']
                 document = {k:v for k, v in document.items() if not k=='META'}
             try:
+                #doc_dump = json.dumps(document)+'\n'
+                #if compression is None:
+                #    self.fileobj.write(doc_dump.encode())
+                #else:
+                #    self.fileobj.write(doc_dump)
                 doc_dump = json.dumps(document)
-                self.fileobj.write(doc_dump+"\n")
+                self.fileobj.write(doc_dump+'\n')
             except:
                 raise "hell"
                 self.failed += 1


### PR DESCRIPTION
This PR fixes an issue with exporting gzipped JSON files, resulting in corrupt files (even though they seemed OK first). This was due to legacy python2 compatible code, and can be prevented by explicitly using text mode instead of binary mode.

The following should now be BOTH possible:

```
myinca.importers_exporters.export_json_file(query='WHATEVER', compression='gz')

myinca.importers_exporters.export_json_file(query='WHATEVER')
```
The first command should result in a json.gz file that can be uncompressed on the linux command line with

```
gunzip filename.json.gz
```

The same should work with export_json_files (plural)