### PR TITLE
created a tagger that returns a bool depending on whether a regexp is…

### DIFF
--- a/inca/processing/regextagger_processing.py
+++ b/inca/processing/regextagger_processing.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from ..core.processor_class import Processer
+import logging
+import re
+
+
+logger = logging.getLogger("INCA")
+
+
+class regex_tagger(Processer):
+    '''Creates a tag that is either True or False, depending on whether regex is found
+    '''
+    def process(self, document_field, regex, **kwargs):
+        '''is regex mentioned?'''
+
+        r = re.compile(regex)
+
+        if r.findall(document_field):
+            return True
+        else:
+            return False


### PR DESCRIPTION
… found

This tagger is meant to addres the issue outlined in #390 .
Using it, we can create a new key that is True if a regular expression is found in a document and False otherwise.

In particular, to create a tag that is True if the political party DENK is mentioned, we could do:

```
 r = [e for e in myinca.processing.regex_tagger('nu','text',regex = r'DENK', new_key='denk')]
```

For testing purposes, it's probably better to use a frequently occuring word like 'zij' or a regexp matching numbers or sth like that.