### PR TITLE
use tqdm instead of logger for progress updates

### DIFF
--- a/inca/core/database.py
+++ b/inca/core/database.py
@@ -19,13 +19,14 @@ import configparser
 import requests
 from celery import Task
 import os
+from tqdm import tqdm
 
 from .filenames import id2filename
 
 config = configparser.ConfigParser()
 config.read('settings.cfg')
 
-logger = logging.getLogger("INCA"+__name__)
+logger = logging.getLogger("INCA")
 logging.getLogger("elasticsearch").setLevel(logging.CRITICAL)
 
 try:
@@ -389,10 +390,7 @@ def scroll_query(query,scroll_time='30m', log_interval=None):
         else:
             update_step = min((total/1000), 100)
 
-    for n, doc in enumerate(helpers.scan(client, query=query, scroll=scroll_time)):
-        if not (n+1 ) % update_step:
-            perc = ((n+1)/total) / 100
-            logger.info("At item {n:10d} of {total} items | {perc:06.2f}".format(n=n+1, total=total, perc=perc))
+    for doc in tqdm(helpers.scan(client, query=query, scroll=scroll_time), total = total):
         yield doc
 
 

--- a/inca/core/search_utils.py
+++ b/inca/core/search_utils.py
@@ -11,7 +11,7 @@ from .basic_utils import dotkeys as _dotkeys
 import _datetime as _datetime
 import json as _json
 
-_logger = _logging.getLogger("INCA.%s" %__name__)
+_logger = _logging.getLogger("INCA")
 
 def list_doctypes():
     if not _DATABASE_AVAILABLE:
@@ -32,13 +32,13 @@ def doctype_generator(doctype):
          _logger.warning("Could not find mapping of doctype, please check whether you are using the correct doctype")
          return []
         
+    if not _DATABASE_AVAILABLE:
+        _logger.warning("Could not get documents: No database instance available")
+        return
     
-    query = {'query':{'term':{field:doctype}}}
-    for num, doc in enumerate(_scroll_query(query)):
-        if not _DATABASE_AVAILABLE:
-            _logger.warning("Could not get documents: No database instance available")
-            break
-        if not num%100: _logger.info("returning {num}".format(**locals()))
+    query = {'query':{'term':{field:doctype}}} 
+
+    for doc in _scroll_query(query):
         yield doc
 
 def document_generator(query="*"):
@@ -70,9 +70,8 @@ def document_generator(query="*"):
             _logger.warning("Unknown input")
             es_query = False
         if es_query:
-            total = _client.search(_elastic_index, body=es_query, size=0)['hits']['total']
-            for num, doc in enumerate(_scroll_query(es_query)):
-                if not num%100: _logger.info("returning {num} of {total}".format(num=num, total=total))
+            # total = _client.search(_elastic_index, body=es_query, size=0)['hits']['total']
+            for doc in _scroll_query(es_query):
                 yield doc
 
 

--- a/inca/importers_exporters/csv.py
+++ b/inca/importers_exporters/csv.py
@@ -107,7 +107,7 @@ class export_csv(Exporter):
         if len(self.fields)==0:
             keys = set.union(*[set(d.keys()) for d in flat_batch])
             [self.fields.append(k) for k in keys if k not in self.fields if k != "_source.htmlsource"]           
-        logger.info('Exporting these fields: {}'.format(self.fields))
+        logger.debug('Exporting these fields: {}'.format(self.fields))
         
         self.extension = "csv"
         if  self.fileobj and not self.fileobj.closed:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = ['celery','colorama','spacy','tqdm','elasticsearch==5.4',
                 'feedparser', 'httplib2','imagehash', 'loremipsum',
                 'lxml','requests','statsmodels','pandas',
                 'pillow==5.0','gensim','oauth2client','matplotlib',
-                'scikit-learn','scipy','selenium','twython','nltk']
+                'scikit-learn','scipy','selenium','twython','nltk','tqdm']
 
 setup(name='inca',
       version='0.1',


### PR DESCRIPTION
Solves issue #403 

When retrieving many documents, e.g. during an export, you now see a progress bar instead of logger output ('100 of 2000 documents').

If not installed, run
```
pip3 install tqdm
```
first