### PR TITLE
Added "save" as a parameter of the .get()-method of usable scrapers...

### DIFF
--- a/inca/scrapers/ASN_scraper.py
+++ b/inca/scrapers/ASN_scraper.py
@@ -25,7 +25,7 @@ class asn(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=11, day=10)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from ASN
         '''

--- a/inca/scrapers/corp_abf_scraper.py
+++ b/inca/scrapers/corp_abf_scraper.py
@@ -68,7 +68,7 @@ class abf(Scraper):
             except:
                 print("no connection:\n" + link)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Banco Santander Central Hispano
         '''

--- a/inca/scrapers/corp_aegon_scraper.py
+++ b/inca/scrapers/corp_aegon_scraper.py
@@ -22,7 +22,7 @@ class aegon(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=6, day=21)
    
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Aegon
         '''

--- a/inca/scrapers/corp_akzonobel_scraper.py
+++ b/inca/scrapers/corp_akzonobel_scraper.py
@@ -19,7 +19,7 @@ class akzonobel(Scraper):
         self.START_URL = "https://www.akzonobel.com/media-releases-and-features"
         self.BASE_URL = "https://www.akzonobel.com/"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Akzo Nobel
         '''

--- a/inca/scrapers/corp_barclays_scraper.py
+++ b/inca/scrapers/corp_barclays_scraper.py
@@ -23,7 +23,7 @@ class barclays(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=27)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Barclays
         '''

--- a/inca/scrapers/corp_bat_scraper.py
+++ b/inca/scrapers/corp_bat_scraper.py
@@ -19,7 +19,7 @@ class bat(Scraper):
         self.START_URL = "http://www.bat.com/group/sites/UK__9D9KCY.nsf/vwPagesWebLive/DO6YLKYF"
         self.BASE_URL = "http://www.bat.com"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from British American Tobacco
         '''

--- a/inca/scrapers/corp_bhp_scraper.py
+++ b/inca/scrapers/corp_bhp_scraper.py
@@ -19,7 +19,7 @@ class bhp(Scraper):
         self.START_URL = "http://www.bhp.com/media-and-insights/news-releases"
         self.BASE_URL = "http://www.bhp.com/"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from BHP Billiton
         '''

--- a/inca/scrapers/corp_bp_scraper.py
+++ b/inca/scrapers/corp_bp_scraper.py
@@ -22,7 +22,7 @@ class bp(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=24)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from BP
         '''

--- a/inca/scrapers/corp_bsch_scraper.py
+++ b/inca/scrapers/corp_bsch_scraper.py
@@ -65,7 +65,7 @@ class bsch(Scraper):
             except:
                 print("no connection:\n" + link)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Banco Santander Central Hispano
         '''

--- a/inca/scrapers/corp_compass_scraper.py
+++ b/inca/scrapers/corp_compass_scraper.py
@@ -22,7 +22,7 @@ class compass(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=26)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Compass Group
         '''

--- a/inca/scrapers/corp_dsm_scraper.py
+++ b/inca/scrapers/corp_dsm_scraper.py
@@ -20,7 +20,7 @@ class dsm(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=18)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from DSM
         '''

--- a/inca/scrapers/corp_gamesa_scraper.py
+++ b/inca/scrapers/corp_gamesa_scraper.py
@@ -22,7 +22,7 @@ class gamesa(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=8, day=21)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Gamesa
         '''

--- a/inca/scrapers/corp_gsk_scraper.py
+++ b/inca/scrapers/corp_gsk_scraper.py
@@ -22,7 +22,7 @@ class gsk(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=24)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from GSK
         '''

--- a/inca/scrapers/corp_kpn_scraper.py
+++ b/inca/scrapers/corp_kpn_scraper.py
@@ -51,7 +51,7 @@ class kpn(Scraper):
             except:
                 print("no connection:\n" + link)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from KPN
         '''

--- a/inca/scrapers/corp_lbg_scraper.py
+++ b/inca/scrapers/corp_lbg_scraper.py
@@ -22,7 +22,7 @@ class lbg(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=27)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Lloyds Banking Group
         '''

--- a/inca/scrapers/corp_mapfre_scraper.py
+++ b/inca/scrapers/corp_mapfre_scraper.py
@@ -22,7 +22,7 @@ class mapfre(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=8, day=1)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Mapfre
         '''

--- a/inca/scrapers/corp_merlin_scraper.py
+++ b/inca/scrapers/corp_merlin_scraper.py
@@ -17,7 +17,7 @@ class merlin(Scraper):
         self.START_URL = "http://www.merlinproperties.com/en/press-release/"
         self.BASE_URL = "http://www.merlinproperties.com/"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Merlin Properties Socimi SA
         '''

--- a/inca/scrapers/corp_randstad_scraper.py
+++ b/inca/scrapers/corp_randstad_scraper.py
@@ -70,7 +70,7 @@ class randstad(Scraper):
             except:
                 print("no connection:\n" + link)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Randstad
         '''

--- a/inca/scrapers/corp_sbm_scraper.py
+++ b/inca/scrapers/corp_sbm_scraper.py
@@ -19,7 +19,7 @@ class sbm(Scraper):
         self.START_URL = "http://www.sbmoffshore.com/investor-relations-centre/press-releases/"
         self.BASE_URL = "http://www.sbmoffshore.com/"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from SBM Offshore
         '''

--- a/inca/scrapers/corp_shell_scraper.py
+++ b/inca/scrapers/corp_shell_scraper.py
@@ -22,7 +22,7 @@ class shell(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=6, day=21)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Shell
         '''

--- a/inca/scrapers/corp_vodafone_scraper.py
+++ b/inca/scrapers/corp_vodafone_scraper.py
@@ -19,7 +19,7 @@ class vodafone(Scraper):
         self.START_URL = "http://www.vodafone.com/content/index/media/vodafone-group-releases.html"
         self.BASE_URL = "http://www.vodafone.com/"
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Vodafone
         '''

--- a/inca/scrapers/corp_vopak_scraper.py
+++ b/inca/scrapers/corp_vopak_scraper.py
@@ -22,7 +22,7 @@ class vopak(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=11)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Vopak
         '''

--- a/inca/scrapers/corp_wolters_scraper.py
+++ b/inca/scrapers/corp_wolters_scraper.py
@@ -22,7 +22,7 @@ class wolters(Scraper):
         self.version = ".1"
         self.date = datetime.datetime(year=2017, month=7, day=18)
 
-    def get(self):
+    def get(self, save):
         '''                                                                             
         Fetches articles from Wolters Kluwer
         '''

--- a/inca/scrapers/facebook_scraper.py
+++ b/inca/scrapers/facebook_scraper.py
@@ -26,7 +26,7 @@ class facebook(Scraper):
         self.START_URL = "https://graph.facebook.com/v2.6/"
 
 	
-    def get(self, pagename, app_id, app_secret, maxpages):
+    def get(self, save, pagename, app_id, app_secret, maxpages):
         '''                                                                     
         Fetches posts from facebook page
         maxpages = number of pages to scrape

--- a/inca/scrapers/hostelworld_scraper.py
+++ b/inca/scrapers/hostelworld_scraper.py
@@ -14,7 +14,7 @@ class hostelworld(Scraper):
         self.BASE_URL = "http://www.hostelworld.com/"
 
     
-    def get(self, maxpages, maxreviewpages, starturl, *args, **kwargs):
+    def get(self, save, maxpages, maxreviewpages, starturl, *args, **kwargs):
         '''
         Fetches reviews from hostelworld.com
         maxpage: number of pages with hostels to scrape

--- a/inca/scrapers/parliamentanswers_scraper.py
+++ b/inca/scrapers/parliamentanswers_scraper.py
@@ -14,7 +14,7 @@ class parliamentanswers_NL(Scraper):
     
 
     
-    def get(self):
+    def get(self, save):
         '''Document collected from officielebekendmakingen.nl by scraping 'bladeren' section  '''
 
         self.doctype = "parliamentary answers NL"

--- a/inca/scrapers/parliamentquestions_scraper.py
+++ b/inca/scrapers/parliamentquestions_scraper.py
@@ -13,7 +13,7 @@ class parliamentquestions_NL(Scraper):
     """Scrapes Dutch parlementary and senate proceedings """
 
     
-    def get(self):
+    def get(self, save):
         '''Document collected from officielebekendmakingen.nl by scraping 'bladeren' section  '''
 
         self.doctype = "parliamentary questions NL"

--- a/inca/scrapers/proceedings_scraper.py
+++ b/inca/scrapers/proceedings_scraper.py
@@ -12,7 +12,7 @@ BASE_URL  = "https://zoek.officielebekendmakingen.nl/"
 class proceedings_NL(Scraper):
     """Scrapes Dutch parlementary and senate proceedings """
     
-    def get(self):
+    def get(self, save):
         '''Document collected from officielebekendmakingen.nl by scraping 'bladeren' section  '''
 
         self.doctype = "proceedings NL"

--- a/inca/scrapers/quotestoscrape_scraper.py
+++ b/inca/scrapers/quotestoscrape_scraper.py
@@ -1,0 +1,60 @@
+import requests
+import datetime
+from lxml import html
+from ..core.scraper_class import Scraper
+from collections import defaultdict
+
+class quotestoscrape(Scraper):
+
+    """A simple example of a scraper. Scrapes quotes.toscrape.com."""
+
+    def __init__(self):
+
+        self.doctype = "quotestoscrape"
+        self.START_URL = "http://quotes.toscrape.com/" # the webpage from where you want to start scraping
+        self.version = ".1"
+        self.datetime = datetime.datetime(year=2018, month=11, day=7)
+
+    def get(self, save, maxpages, *args, **kwargs):
+
+        """
+        Gets quotes from Quotes to Scrape.
+        Places them in a dictionary, using author as key.
+        maxpages: number of pages to be scraped.    
+        """
+
+        quotes = [] # create a list for the scraped quotes
+        authors = [] # create a list for the scraped author names
+        pageno = 1 # start scraping from page number one
+
+        while pageno <= maxpages:
+            current_url = self.START_URL+"page/"+str(pageno)+"/"
+            page = requests.get(current_url)
+            tree=html.fromstring(page.content) 
+            quotes.extend(tree.xpath('//span[@class="text"]/text()'))  
+            authors.extend(tree.xpath('//small[@class="author"]/text()')) 
+            pageno=pageno+1 
+        dictionary = defaultdict(list)
+        for k, v in zip(authors, quotes):
+            dictionary[k].append(v)
+
+        yield(dictionary)
+
+# Testing:
+# from inca import Inca
+# from inca.scrapers.groenlinks_scraper import groenlinks
+# data = myinca.scrapers.groenlinks(save=False, maxpages = 3, startpage = 1) 
+# print(data)
+
+# This worked for a while...
+# from inca.scrapers.quotestoscrape_scraper import quotestoscrape
+# scraping = quotestoscrape()
+# data = scraping.get(save  = False, maxpages = 5)
+# ... No longer works!
+
+# Now it no longer works (although I didn't change the script?). Instead, this works...
+# data = myinca.scrapers.quotestoscrape(save = False, maxpages = 5)
+# ...but the output is weird: it yields all other kinds of things as well, not only the dictionary!
+# ... no problem, that is added automatically by INCA!
+# data[0].keys()
+# data[0]["Mother Theresa"]

--- a/inca/scrapers/voedingforum_scraper.py
+++ b/inca/scrapers/voedingforum_scraper.py
@@ -22,7 +22,7 @@ class voedingsforum(Scraper):
         self.BASE_URL = "http://www.voedingsforum.nl/"
 
         
-    def get(self, maxfora, forumid, maxthreads, maxpages, *args, **kwargs):
+    def get(self, save, maxfora, forumid, maxthreads, maxpages, *args, **kwargs):
         '''                                                                     
         Fetches articles from Voedingsforum
         maxfora = maximum number of forums to scrape


### PR DESCRIPTION
... given that it was missing. In inca/inca/scrapers. Tested locally: the scrapers no longer give the error that says: get()-method takes 1 argument (2 given). 