### PR TITLE
made automated recognition of doctypes for processors ES6-compatible

### DIFF
--- a/inca/core/processor_class.py
+++ b/inca/core/processor_class.py
@@ -196,7 +196,7 @@ def _doctype_query_or_list(doctype_query_or_list, force=False, field=None, task=
     if type(doctype_query_or_list)==list:
         documents = doctype_query_or_list
     elif type(doctype_query_or_list)==str:
-        if doctype_query_or_list in core.database.client.indices.get_mapping()[config.get('elasticsearch','document_index')]['mappings'].keys():
+        if doctype_query_or_list in core.search_utils.list_doctypes():
             logger.info("assuming documents of given type should be processed")
             if force or not field:
                 documents = core.database.scroll_query({'query':{'term':{"doctype":"%s"%doctype_query_or_list}}})


### PR DESCRIPTION
The processor class relied on doctype concept of ES<6, changed it to work with ES6.

Can you check whether it works as expected on your machine as well?