### PR TITLE
Softcosine days

### DIFF
--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -64,7 +64,7 @@ class softcosine_similarity(Analysis):
 
     def fit(self, path_to_model, source, target, sourcetext = 'text', sourcedate = 'publication_date',
             targettext = 'text', targetdate = 'publication_date', keyword_source = None, keyword_target = None, condition_source = None, condition_target = None, days_before = None,
-            days_after = None, merge_weekend = False, threshold = None, from_time=None, to_time=None, to_csv = False, destination='comparisons', to_pajek = False):
+            days_after = None, include_monday = False, threshold = None, from_time=None, to_time=None, to_csv = False, destination='comparisons', to_pajek = False):
         '''
         path_to_model = Supply a pre-trained word2vec model. Information on how to train such a model
         can be found here: https://rare-technologies.com/word2vec-tutorial/
@@ -184,25 +184,47 @@ class softcosine_similarity(Analysis):
                 target_ids_new = []
                 target_doctype_new = []
                 for targettd in target_tuple:
-                    if merge_weekend == True:
-                        day_diff = self.date_comparison_6days(sourcetd[1], targettd[1])
-                    else:
-                        day_diff = self.date_comparison(sourcetd[1], targettd[1])
+                    day_diff = self.date_comparison(targettd[1], sourcetd[1])
 
-                    if days_before <= day_diff[2] <= days_after:
-                        texts_new.append(targettd[0])
-
-                        source_dates_new.append(sourcetd[1])
-                        target_dates_new.append(targettd[1])
-                        print("source date:", sourcetd[1], ", target date:", targettd[1])
-                        source_ids_new.append(sourcetd[2])
-                        target_ids_new.append(targettd[2])
-                        source_doctype_new.append(sourcetd[3])
-                        target_doctype_new.append(targettd[3])
-                    elif day_diff == "No date":
-                        pass
+                    if include_monday == True:
+                        #convert source date to datetime object
+                        source_date_object = [int(i) for i in sourcetd[1][:10].split("-")]
+                        #print(source_date_object)
+                        source_date_object = datetime.date(source_date_object[0], source_date_object[1], source_date_object[2])
+                        #print(source_date_object)
+                        if days_after == 2 and source_date_object.weekday() == 4:
+                            # include monday if source_date is Friday and days_after is 2 days.
+                            days_after = days_after+1
+                            if days_before <= day_diff[2] <= days_after:
+                                texts_new.append(targettd[0])
+                                source_dates_new.append(sourcetd[1])
+                                target_dates_new.append(targettd[1])
+                                source_ids_new.append(sourcetd[2])
+                                target_ids_new.append(targettd[2])
+                                source_doctype_new.append(sourcetd[3])
+                                target_doctype_new.append(targettd[3])
+                            else:
+                                pass
+                        else:
+                            if days_before <= day_diff[2] <= days_after:
+                                texts_new.append(targettd[0])
+                                source_dates_new.append(sourcetd[1])
+                                target_dates_new.append(targettd[1])
+                                source_ids_new.append(sourcetd[2])
+                                target_ids_new.append(targettd[2])
+                                source_doctype_new.append(sourcetd[3])
+                                target_doctype_new.append(targettd[3])
+                            else:
+                                pass
                     else:
-                        pass
+                        if days_before <= day_diff[2] <= days_after:
+                            texts_new.append(targettd[0])
+                            source_dates_new.append(sourcetd[1])
+                            target_dates_new.append(targettd[1])
+                            source_ids_new.append(sourcetd[2])
+                            target_ids_new.append(targettd[2])
+                            source_doctype_new.append(sourcetd[3])
+                            target_doctype_new.append(targettd[3])
                     
                 texts_final.append(texts_new)
                 
@@ -340,10 +362,9 @@ class softcosine_similarity(Analysis):
                 now = time.localtime()
                 nx.write_pajek(G, os.path.join(destination, r"INCA_softcosine_{source}_{target}_{now.tm_year}_{now.tm_mon}_{now.tm_mday}_{now.tm_hour}_{now.tm_min}_{now.tm_sec}.net".format(now=now, target=target, source=source)))
 
-            # Weekend_merge without days_before/days_after
-            if merge_weekend == True:
-                logger.info('Merge_weekend is specified without days_before/days_after and will be ignored.')
-                pass
+            # include_monday without days_before/days_after
+            if include_monday == True:
+                logger.info('Include_monday is specified without days_before/days_after and will be ingnored.')
         
     def predict(self, *args, **kwargs):
         pass

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -333,9 +333,10 @@ class softcosine_similarity(Analysis):
 
             # change int to str (necessary for pajek format)
             df['similarity'] = df['similarity'].apply(str)
-
+            # change column name to 'weights' to faciliate later analysis
+            df.rename({'similarity':'weight'}, axis=1, inplace=True) 
             # notes and weights from dataframe
-            G = nx.from_pandas_edgelist(df, source='source', target='target', edge_attr='similarity')
+            G = nx.from_pandas_edgelist(df, source='source', target='target', edge_attr='weight')
             # write to pajek
             now = time.localtime()
             nx.write_pajek(G, os.path.join(destination, r"INCA_softcosine_{source}_{target}_{now.tm_year}_{now.tm_mon}_{now.tm_mday}_{now.tm_hour}_{now.tm_min}_{now.tm_sec}.net".format(now=now, target=target, source=source)))

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -134,7 +134,7 @@ class softcosine_similarity(Analysis):
 
         logger.info('Preparing dictionary')
         dictionary = Dictionary(corpus)
-        logger.info('Removing all tokens that occur in less than {} documents or in more than {:.1f}\% or all documents from dictionary'.format(filter_below,filter_above*100))
+        logger.info('Removing all tokens that occur in less than {} documents or in more than {:.1f}% or all documents from dictionary'.format(filter_below,filter_above*100))
         dictionary.filter_extremes(no_below=filter_below, no_above=filter_above)
         logger.info('Preparing tfidf model')
         tfidf = TfidfModel(dictionary=dictionary)
@@ -211,7 +211,7 @@ class softcosine_similarity(Analysis):
                             if not grouped_query_new:
                                 grouped_query_new.append(group)
                             else:
-                                grouped_query_new.extend(group)
+                                grouped_query_new[-1].extend(group)
                         # if empty, append empty list
                         elif not group:
                             grouped_query_new.append([])
@@ -247,12 +247,15 @@ class softcosine_similarity(Analysis):
                     else:
                         logger.debug('It should do this 4 times!!')
                         for doc in e[source_pos]:
-                            if doc['identifier']=='source':
-                                # create sourcetext list to compare against
-                                source_texts.append(doc['_source'][sourcetext].split())
-                                # extract additional information
-                                source_ids.append(doc['_id'])
-                                
+                            try:
+                                if doc['identifier']=='source':
+                                    # create sourcetext list to compare against
+                                    source_texts.append(doc['_source'][sourcetext].split())
+                                    # extract additional information
+                                    source_ids.append(doc['_id'])
+                            except:
+                                logger.error('This does not seem to be a valid document')
+                                print(doc)
                         #print('The length of source_texts is', len(source_texts))
 
                         # create index of source texts

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -220,44 +220,46 @@ class softcosine_similarity(Analysis):
                 for e in tqdm(self.window(grouped_query, n = len_window)):
                     source_texts = []
                     source_ids = [] 
-                    for doc in e[source_pos]:
-                        try:
-                            if doc['identifier']=='source':
-                                # create sourcetext list to compare against
-                                source_texts.append(doc['_source'][sourcetext].split())
-                                # extract additional information
-                                source_ids.append(doc['_id'])
 
-                                # create index of source texts
-                                query = tfidf[[dictionary.doc2bow(d) for d in source_texts]]
-                                
-                        except:
-                            logger.error('This does not seem to be a valid document')
-                            print(doc)
-                            pass # no source docs, so pass
-
-                    # iterate through targets
-                    for d in e:
-                        target_texts=[]
-                        target_ids = []
-
-                        for doc in d:
+                    if not e[source_pos]:
+                        pass
+                    else:
+                        for doc in e[source_pos]:
                             try:
-                                if doc['identifier'] == 'target':
-                                    target_texts.append(doc['_source'][targettext].split())
+                                if doc['identifier']=='source':
+                                    # create sourcetext list to compare against
+                                    source_texts.append(doc['_source'][sourcetext].split())
                                     # extract additional information
-                                    target_ids.append(doc['_id'])
-                
+                                    source_ids.append(doc['_id'])
+                            except:
+                                logger.error('This does not seem to be a valid document')
+                                print(doc)
+
+                        # create index of source texts
+                        query = tfidf[[dictionary.doc2bow(d) for d in source_texts]]
+                                
+                            
+                        # iterate through targets
+                        for d in e:
+                            target_texts=[]
+                            target_ids = []
+
+                            for doc in d:
+                                try:
+                                    if doc['identifier'] == 'target':
+                                        target_texts.append(doc['_source'][targettext].split())
+                                        # extract additional information
+                                        target_ids.append(doc['_id'])
+                                        
                                     # do comparison
                                     index = SoftCosineSimilarity(tfidf[[dictionary.doc2bow(d) for d in target_texts]], similarity_matrix)
                                     sims = index[query]
                                     #make dataframe
                                     df_temp = pd.DataFrame(sims, columns=target_ids, index = source_ids).stack().reset_index()
                                     df_list.append(df_temp)
-                            except:
-                                logger.error('This does not seem to be a valid document')
-                                print(doc)
-                                pass # no target docs or no query, so pass
+                                except:
+                                    logger.error('This does not seem to be a valid document')
+                                    print(doc)
                     
                 # make total dataframe
                 df = pd.concat(df_list, ignore_index=True)

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -245,7 +245,7 @@ class softcosine_similarity(Analysis):
                         ## TO DO ------ DO NOT CREATE LISTS OF TEXTS; THIS TAKES TOO LONG.
                         pass
                     else:
-                        print('It should do this 4 times!!')
+                        logger.debug('It should do this 4 times!!')
                         for doc in e[source_pos]:
                             if doc['identifier']=='source':
                                 # create sourcetext list to compare against
@@ -266,7 +266,7 @@ class softcosine_similarity(Analysis):
                                 #print('This is empty :)')
                                 pass # empty list, so pass comparison
                             else:
-                                print('It should do this 4 times as well!!!')
+                                logger.debug('It should do this 4 times as well!!!')
                                 for doc in d:
                                     if doc['identifier'] == 'target':
                                         target_texts.append(doc['_source'][targettext].split())
@@ -280,7 +280,7 @@ class softcosine_similarity(Analysis):
                                 df_list.append(df_temp)
                                 #print(df_temp)
                 #print('This is the last df_temp that was made:', df_temp)
-                print('The length of df_list is now:', len(df_list))
+                logger.debug('The length of df_list is now:', len(df_list))
                 
                 # make total dataframe
                 df = pd.concat(df_list, ignore_index=True)

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -39,28 +39,6 @@ class softcosine_similarity(Analysis):
                 second = datetime.date(second[0], second[1], second[2])
                 difference = (first-second).days
             return([first, second, difference])
-        
-    def date_comparison_6days(self, first_date, second_date):
-        '''Returns the date difference when sunday is merged with monday'''
-        c_weekmask = 'Mon Tue Wed Thu Fri Sat'
-        cbday = CustomBusinessDay(0, weekmask=c_weekmask)
-        if first_date is None or second_date is None:
-            return("No date")
-        else:
-            try:    #assume datetime objects
-                first_date2 = first_date.days+cbday
-                second_date2 = second_date.days+cbday
-                difference = (first_date2 - second_date2)
-            except:  # handle strings
-                first = [int(i) for i in first_date[:10].split("-")]
-                first = datetime.date(first[0], first[1], first[2])
-                first2 = first+cbday
-                second = [int(i) for i in second_date[:10].split("-")]
-                second = datetime.date(second[0], second[1], second[2])
-                second2 = second+cbday
-                difference = (first2-second2).days
-            return([first, second, difference])
-            
 
     def fit(self, path_to_model, source, target, sourcetext = 'text', sourcedate = 'publication_date',
             targettext = 'text', targetdate = 'publication_date', keyword_source = None, keyword_target = None, condition_source = None, condition_target = None, days_before = None,
@@ -74,7 +52,7 @@ class softcosine_similarity(Analysis):
         sourcdate/targetedate = field where date of source/target can be found (defaults to 'publication_date')
         keyword_source/_target = optional: specify keywords that need to be present in the textfield; list or string, in case of a list all words need to be present in the textfield (lowercase)
         condition_source/target = optional: supply the field and its value as a dict as a condition for analysis, e.g. {'topic':1} (defaults to None)
-        days_before = days target is before source (e.g. 2); days_after = days target is after source (e.g. 2) -> either both or none should be supplied. If you additionally specify merge_weekend=True, sunday will be merged with monday to account for publishing in weekends (default is False).
+        days_before = days target is before source (e.g. 2); days_after = days target is after source (e.g. 2) -> either both or none should be supplied. Additionally, include_monday = True includes Monday if source date is Friday and days_after is 2. 
         threshold = threshold to determine at which point similarity is sufficient; if supplied only the rows who pass it are included in the dataset
         from_time, to_time = optional: specifying a date range to filter source and target articles. Supply the date in the yyyy-MM-dd format.
         to_csv = if True save the resulting data in a csv file - otherwise a pandas dataframe is returned
@@ -189,9 +167,7 @@ class softcosine_similarity(Analysis):
                     if include_monday == True:
                         #convert source date to datetime object
                         source_date_object = [int(i) for i in sourcetd[1][:10].split("-")]
-                        #print(source_date_object)
                         source_date_object = datetime.date(source_date_object[0], source_date_object[1], source_date_object[2])
-                        #print(source_date_object)
                         if days_after == 2 and source_date_object.weekday() == 4:
                             # include monday if source_date is Friday and days_after is 2 days.
                             days_after = days_after+1

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -250,16 +250,16 @@ class softcosine_similarity(Analysis):
                                         target_texts.append(doc['_source'][targettext].split())
                                         # extract additional information
                                         target_ids.append(doc['_id'])
-                                        
-                                    # do comparison
-                                    index = SoftCosineSimilarity(tfidf[[dictionary.doc2bow(d) for d in target_texts]], similarity_matrix)
-                                    sims = index[query]
-                                    #make dataframe
-                                    df_temp = pd.DataFrame(sims, columns=target_ids, index = source_ids).stack().reset_index()
-                                    df_list.append(df_temp)
                                 except:
                                     logger.error('This does not seem to be a valid document')
-                                    print(doc)
+                                    print(doc)  
+                            # do comparison
+                            index = SoftCosineSimilarity(tfidf[[dictionary.doc2bow(d) for d in target_texts]], similarity_matrix)
+                            sims = index[query]
+                            #make dataframe
+                            df_temp = pd.DataFrame(sims, columns=target_ids, index = source_ids).stack().reset_index()
+                            df_list.append(df_temp)
+                     
                     
                 # make total dataframe
                 df = pd.concat(df_list, ignore_index=True)

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -188,10 +188,8 @@ class softcosine_similarity(Analysis):
                         day_diff = self.date_comparison_6days(sourcetd[1], targettd[1])
                     else:
                         day_diff = self.date_comparison(sourcetd[1], targettd[1])
-                    
-                    if day_diff == "No date" or day_diff[2]<days_before or day_diff[2]>days_after:
-                        pass
-                    else:
+
+                    if days_before <= day_diff[2] <= days_after:
                         texts_new.append(targettd[0])
 
                         source_dates_new.append(sourcetd[1])
@@ -200,6 +198,11 @@ class softcosine_similarity(Analysis):
                         target_ids_new.append(targettd[2])
                         source_doctype_new.append(sourcetd[3])
                         target_doctype_new.append(targettd[3])
+                    elif day_diff == "No date":
+                        pass
+                    else:
+                        pass
+                    
                 texts_final.append(texts_new)
                 
                 source_dates_final.extend(source_dates_new)

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -194,6 +194,7 @@ class softcosine_similarity(Analysis):
 
                         source_dates_new.append(sourcetd[1])
                         target_dates_new.append(targettd[1])
+                        print("source date:", sourcetd[1], ", target date:", targettd[1])
                         source_ids_new.append(sourcetd[2])
                         target_ids_new.append(targettd[2])
                         source_doctype_new.append(sourcetd[3])

--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -17,8 +17,6 @@ from gensim.similarities import SoftCosineSimilarity
 import time
 import networkx as nx
 
-from pandas.tseries.offsets import CustomBusinessDay
-
 
 
 logger = logging.getLogger("INCA")


### PR DESCRIPTION
Softcosine_similarity now has include_monday parameter. 

Tried several things, including CustomBusinessDays, to merge Saturday and Sunday, but it did not work out with the way we set up our softcosine code. I think this is only useful, like in our news event project, where you have a 3-day sliding window and you want to include articles published on Mondays when the window starts on a Friday (because not much is published on Sundays). That is why I did it as follows:

```python
if days_after == 2 and source_date_object.weekday() == 4:
days_after = days_after+1
#create lists of relevant targets per source
``` 
Let me know if there is a better solution... 

Additionally found mistake in calculating day_diff. It is now: target date - source date (e.g. '2018-12-07' - '2018-12-08' = -1, as it should be). How this mistake was still in here is a mystery to me...?