### PR TITLE
too new versions of celery populate importers, scrapers etc. only wit…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-requirements = ['celery','colorama','tqdm','elasticsearch>=6',
+requirements = ['celery>3.1,<4.0','colorama','tqdm','elasticsearch>=6',
                 'feedparser', 'httplib2','imagehash', 'loremipsum',
                 'lxml','requests<3.0.0,>=2.13.0','statsmodels','pandas',
                 'pillow==5.0','gensim>3.4','oauth2client','matplotlib',


### PR DESCRIPTION
…h mro, nothing else

(just a change in the requirements because we do not support too new versions of celery yet)