### PR TITLE
added deduplication function

### DIFF
--- a/Requirements
+++ b/Requirements
@@ -42,7 +42,7 @@ python-dateutil==2.5.3
 pytz==2013b0
 requests==2.10.0
 requests-oauthlib==0.6.2
-requirements==0.1
+# requirements==0.1
 rsa==3.4.2
 scipy>=0.18.0
 scikit-learn>=0.19.1
@@ -69,4 +69,4 @@ Pillow==4.3.0
 tqdm
 newspaper3k
 spacy
-https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.0.0/nl_core_news_sm-2.0.0.tar.gz
+https://github.com/explosion/spacy-models/releases/download/nl_core_news_sm-2.1.0/nl_core_news_sm-2.1.0.tar.gz

--- a/inca/core/search_utils.py
+++ b/inca/core/search_utils.py
@@ -6,6 +6,7 @@ from .database import scroll_query as _scroll_query
 from .database import elastic_index as _elastic_index
 from .database import DATABASE_AVAILABLE as _DATABASE_AVAILABLE
 from .database import delete_doctype, delete_document, insert_document, insert_documents
+from .database import deduplicate
 import logging as _logging
 from .basic_utils import dotkeys as _dotkeys
 import _datetime as _datetime


### PR DESCRIPTION
I added a deduplication-function that removes duplicate entries based on text, title, publication date (typically within a doctype).

Please test carefully locally on your machines  before we try this on the server.

This is how I tested it:

1. Add 10 duplicate docs
```
g = myinca.database.doctype_examples('nu')
[myinca.database.insert_document(d) for d in g]
```

2. Find them back
```
g = myinca.database.doctype_generator('nu') 
myinca.database.deduplicate(g, dryrun=True)
```

3. Really delete them
```
g2 = myinca.database.doctype_generator('nu') 
myinca.database.deduplicate(g2, dryrun=False)
```

And, of course, check all the time whether `myinca.database.list_doctypes()` gives you the expected number of documetns.