### PR TITLE
Reparse

### DIFF
--- a/inca/core/.#taskmanager.py
+++ b/inca/core/.#taskmanager.py
@@ -1,1 +1,0 @@
-rnvdv@vpn-stud-146-50-146-65.vpn.uva.nl.58847

--- a/inca/core/database.py
+++ b/inca/core/database.py
@@ -636,7 +636,7 @@ def reparse(g, f, force=False):
             logger.info('Overwriting extisting text for {}, reparsing'.format(_id))
             text_new = f(None,htmlsource)['text'] 
         else:
-            logger.info('Old text exists, will not overwrite')
+            logger.debug('Old text exists, will not overwrite')
             continue
 
         logger.info("Old text: {} characters, first 30: {}".format(
@@ -646,5 +646,7 @@ def reparse(g, f, force=False):
 
 
         doc['_source']['text'] = text_new
+        if len(text_old.strip())>1:
+            doc['_source']['text_old'] = text_old   # to be sure, store old text as well
 
         update_document(doc, force=True) # this force=True has nothing to do with the parameter passed to reparse()

--- a/inca/core/database.py
+++ b/inca/core/database.py
@@ -596,10 +596,17 @@ def deduplicate(g, dryrun=True, check_keys = ["text", "title", "doctype", "publi
 # FIX BROKEN DOCUMENTS
 ######################
 
-def reparse(g, f, dryrun=True, force=False):
+def reparse(g, f, force=False):
     '''
     Takes a document generator `g` as reparses the `htmlsource` key using
-    a parse function f
+    a parse function f taken from an INCA-scraper.
+  
+    In the current implementation, only the text field is considered.
+    By default, the text field is only updated if it was empty.
+
+    Arguments
+    ---------
+    force (bool): If True, non-empty text is replaced as well.
 
     Example usage:
     ```
@@ -607,10 +614,12 @@ def reparse(g, f, dryrun=True, force=False):
     f = news_scraper.nu.parsehtml 
    
     g = myinca.database.document_generator('doctype:"nu" AND publication_date:[2017-01-01 TO 2017-03-15]')
-
-    myinca.database.reparse(g, f, dryrun = True)
+    myinca.database.reparse(g, f, force = False)
     ```
     '''
+
+    # TODO reparse now only repareses the the texts, not other fields (such as author, title etc)
+    # To implement that, we need a better logic on which fields are to be replaced when
     
     for doc in g:
         text_old = doc['_source'].get('text', '')
@@ -622,10 +631,10 @@ def reparse(g, f, dryrun=True, force=False):
         _id = doc["_id"]
         if text_old.strip() == '':
             logger.info('No text available for {}, reparsing'.format(_id))
-            text_new = f(None, htmlsource)['text'] # TODO WHAT IF NO SELF?
+            text_new = f(None, htmlsource)['text'] 
         elif force==True:
             logger.info('Overwriting extisting text for {}, reparsing'.format(_id))
-            text_new = f(None,htmlsource)['text'] # TODO WHAT IF NO SELF?
+            text_new = f(None,htmlsource)['text'] 
         else:
             logger.info('Old text exists, will not overwrite')
             continue
@@ -638,4 +647,4 @@ def reparse(g, f, dryrun=True, force=False):
 
         doc['_source']['text'] = text_new
 
-        update_document(doc, force=True)
+        update_document(doc, force=True) # this force=True has nothing to do with the parameter passed to reparse()

--- a/inca/core/search_utils.py
+++ b/inca/core/search_utils.py
@@ -6,7 +6,7 @@ from .database import scroll_query as _scroll_query
 from .database import elastic_index as _elastic_index
 from .database import DATABASE_AVAILABLE as _DATABASE_AVAILABLE
 from .database import delete_doctype, delete_document, insert_document, insert_documents
-from .database import deduplicate
+from .database import deduplicate, reparse
 import logging as _logging
 from .basic_utils import dotkeys as _dotkeys
 import _datetime as _datetime


### PR DESCRIPTION
This PR provides a simpler way to re-parse HTML code of existing documents if the parser was broken and has been fixed in the meantime.

To test locally, first artificiallty remove the text of a document:

```from inca.core import database
from inca import Inca

myinca = Inca()

doc = myinca.database.doctype_last('nu')[0]

doc['_source']['text'] = ''
database.update_document(doc, force=True)

# check whether text really has been removed:
g = myinca.database.document_generator('_id:"{}"'.format(doc['_id']))
print(next(g))```

Then, reparse all documents. By default, only documents where the text is missing are re-parsed:
```from inca import Inca
myinca = Inca() 
from inca.rssscrapers import news_scraper
f = news_scraper.nu.parsehtml
g = myinca.database.doctype_generator('nu')

myinca.database.reparse(g, f,  force=False)```

Check whether nothing is messed up.



Finally, if running with `force=True` instead, it should reparse everything (which may be a VERY bad idea if the parser doesn't work and it overwrites existing stuff.


