### PR TITLE
merge_weekend now passes empty list first

### DIFF
--- a/inca/analysis/softcosine_analysis.py
+++ b/inca/analysis/softcosine_analysis.py
@@ -208,15 +208,15 @@ class softcosine_similarity(Analysis):
                 if merge_weekend == True:
                     grouped_query_new = []
                     for group in grouped_query:
+                        # if empty, append empty list
+                        if not group:
+                            grouped_query_new.append([])
                         # if group is sunday, extend previous (saturday) list, except when it is the first day in the data.
-                        if group[0]['_source'][sourcedate].weekday()==6:
+                        elif group[0]['_source'][sourcedate].weekday()==6:
                             if not grouped_query_new:
                                 grouped_query_new.append(group)
                             else:
                                 grouped_query_new[-1].extend(group)
-                        # if empty, append empty list
-                        elif not group:
-                            grouped_query_new.append([])
                         # for all other weekdays, append new list
                         else:
                             grouped_query_new.append(group)


### PR DESCRIPTION
Following error occured in softcosine analysis: Trying to find first element in the list, while list can be empty.
```
    if group[0]['_source'][sourcedate].weekday()==6:
IndexError: list index out of range 
```
Fixed by first passing if list is empty before trying to find first element in the list group. 
