### PR TITLE
Nick's scrapers

### DIFF
--- a/inca/rssscrapers/aachenerzeitung_scraper.py
+++ b/inca/rssscrapers/aachenerzeitung_scraper.py
@@ -25,7 +25,7 @@ class aachenerzeitung(rss):
             "https://www.aachener-zeitung.de/nrw-region/feed.rss",
         ]
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=3, day=29)
+        self.date = datetime.datetime(year=2020, month=4, day=8)
 
     def parsehtml(self, htmlsource):
         """
@@ -46,7 +46,6 @@ class aachenerzeitung(rss):
             category = tree.xpath('//*[@class="park-section-breadcrumb__link "]//span/text()')[1]
         except:
             category = ""
-
         # title: consists out of two parts, a kicker and a headline:
         # title1
         try:
@@ -58,7 +57,12 @@ class aachenerzeitung(rss):
             title2 = tree.xpath('//*[@class="park-article__headline"]/text()')
         except:
             title2 = ""
-        title = ": ".join(title1 + title2).replace("\n", "")
+        title = title1 + title2
+        title = ": ".join(title).strip().replace("\n", "").replace("         ", "").replace("        ", "")
+        if title.startswith(":") == True:
+            title = title.strip().replace(":", "")
+        else:
+            title = title
         # teaser
         try:
             teaser = "".join(tree.xpath('//*[@class="park-article__intro park-article__content"]/text()')).strip().replace("\n", "")
@@ -69,10 +73,12 @@ class aachenerzeitung(rss):
             author = "".join(tree.xpath('//*[@class="park-article__sign"]/text()'))
         except:
             author = ""
+        author = author.replace("(", "").replace(")", "")
         # text
         try:
             text = "".join(tree.xpath('//*[@class="park-article-content"]//p/text()'))
         except:
+            logger.warning("Text could not be accessed - most likely a premium article")
             text = ""
 
         extractedinfo = {

--- a/inca/rssscrapers/diewelt_scraper.py
+++ b/inca/rssscrapers/diewelt_scraper.py
@@ -16,7 +16,7 @@ class diewelt(rss):
         self.doctype = "die welt (www)"
         self.rss_url = "https://www.welt.de/feeds/latest.rss"
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=4, day=7)
+        self.date = datetime.datetime(year=2020, month=4, day=8)
 
     def parsehtml(self, htmlsource):
         """
@@ -68,7 +68,7 @@ class diewelt(rss):
         text = firstletter + text
         # author
         try:
-            author = "".join(tree.xpath('//*[@class="c-author"]//a/text()|//*[@class="c-author"]//span/text()'))
+            author = "".join(tree.xpath('//*[@class="c-author"]//a/text()'))
         except:
             logger.warning("No author")
             author = ""

--- a/inca/rssscrapers/diewelt_scraper.py
+++ b/inca/rssscrapers/diewelt_scraper.py
@@ -8,7 +8,7 @@ import re
 import logging
 logger = logging.getLogger("INCA")
 
-# Die Welt - Politik
+# Die Welt
 class diewelt(rss):
     """Scrapes the latest news from welt.de"""
 
@@ -16,7 +16,7 @@ class diewelt(rss):
         self.doctype = "die welt (www)"
         self.rss_url = "https://www.welt.de/feeds/latest.rss"
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=3, day=30)
+        self.date = datetime.datetime(year=2020, month=4, day=7)
 
     def parsehtml(self, htmlsource):
         """
@@ -37,48 +37,40 @@ class diewelt(rss):
             category = tree.xpath('//*[@class="c-breadcrumb"]//a/span/text()')[1]
         except:
             category = ""
-
         # teaser
         try:
             teaser = " ".join(tree.xpath('//*[@class="c-summary__intro"]//text()'))
         except:
             teaser = ""
+        teaser = teaser.strip()
         # title
         try:
-            title1 = tree.xpath(
-                '//*[@class="rf-o-topic c-topic"]//text()'
-            )
+            title1 = tree.xpath('//*[@class="rf-o-topic c-topic"]//text()')
         except:
             title1 = ""
         try:
-            title2 = tree.xpath(
-                '//*[@class="c-headline o-dreifaltigkeit__headline rf-o-headline"]//text()'
-            )
+            title2 = tree.xpath('//*[@class="c-headline o-dreifaltigkeit__headline rf-o-headline"]//text()')
         except:
             title2 = ""
         title = ": ".join(title1 + title2).strip()
 
         # text
         try:
-            text = " ".join(
-                tree.xpath(
-                    '//*[@itemprop="articleBody"]//p/text()|//*[@itemprop="articleBody"]//h3/text()'
-                )
-            )
+            text = " ".join(tree.xpath('//*[@itemprop="articleBody"]//p/text()|//*[@itemprop="articleBody"]//h3/text()'))
         except:
+            logger.warning("Text could not be accessed - most likely a premium article")
             text = ""
         ## firstletter
         try:
-            firstletter = "".join(
-                tree.xpath('//*[@itemprop="articleBody"]/p/span/text()')
-            )
+            firstletter = "".join(tree.xpath('//*[@itemprop="articleBody"]/p/span/text()'))
         except:
             firstletter = ""
         text = firstletter + text
         # author
         try:
-            author = "".join(tree.xpath('//*[@class="c-author"]//a/text()'))
+            author = "".join(tree.xpath('//*[@class="c-author"]//a/text()|//*[@class="c-author"]//span/text()'))
         except:
+            logger.warning("No author")
             author = ""
         author = author.strip()
 

--- a/inca/rssscrapers/diewelt_scraper.py
+++ b/inca/rssscrapers/diewelt_scraper.py
@@ -52,7 +52,7 @@ class diewelt(rss):
             title2 = tree.xpath('//*[@class="c-headline o-dreifaltigkeit__headline rf-o-headline"]//text()')
         except:
             title2 = ""
-        title = ": ".join(title1 + title2).strip()
+        title = ": ".join(title1 + title2).strip().replace("\xa0", "")
 
         # text
         try:

--- a/inca/rssscrapers/rheinischepost_scraper.py
+++ b/inca/rssscrapers/rheinischepost_scraper.py
@@ -31,7 +31,7 @@ class rheinischepost(rss):
             "https://rp-online.de/leben/beruf/feed.rss", 
         ]
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=3, day=23)
+        self.date = datetime.datetime(year=2020, month=4, day=7)
 
     def parsehtml(self, htmlsource):
         """
@@ -58,7 +58,12 @@ class rheinischepost(rss):
             title2 = tree.xpath('//*[@class="park-article__headline"]/text()')
         except:
             title2 = ""
-        title = ": ".join(title1 + title2).strip().replace("\n", "")
+        title = title1 + title2
+        title = ": ".join(title).strip().replace("\n", "").replace("         ", "").replace("        ", "")
+        if title.startswith(":") == True:
+            title = title.strip().replace(":", "")
+        else:
+            title = title
         # teaser
         try:
             teaser = tree.xpath('//*[@class="park-article__intro park-article__content"]/text()')[1]
@@ -70,10 +75,12 @@ class rheinischepost(rss):
             author = "".join(tree.xpath('//*[@class="park-article__sign"]/text()'))
         except:
             author = ""
+        author = author.strip().replace("(", "").replace(")", "")
         # text
         try:
             text = "".join(tree.xpath('//*[@class="park-article-content"]//p/text()'))
         except:
+            logger.warning("Text could not be accessed - most likely a premium article")
             text = ""
         # category
         try:

--- a/inca/rssscrapers/rheinischepost_scraper.py
+++ b/inca/rssscrapers/rheinischepost_scraper.py
@@ -6,7 +6,6 @@ from inca.core.database import check_exists
 import feedparser
 import re
 import logging
-
 logger = logging.getLogger("INCA")
 
 

--- a/inca/rssscrapers/sueddeutsche_scraper.py
+++ b/inca/rssscrapers/sueddeutsche_scraper.py
@@ -16,7 +16,7 @@ class diesueddeutsche(rss):
         self.doctype = "sueddeutschet politik (www)"
         self.rss_url = "https://rss.sueddeutsche.de/app/service/rss/alles/index.rss?output=rss"
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=3, day=29)
+        self.date = datetime.datetime(year=2020, month=4, day=7)
 
     def parsehtml(self, htmlsource):
         """
@@ -35,54 +35,46 @@ class diesueddeutsche(rss):
             logger.warning("HTML tree cannot be parsed")
 
         # category
-        """ The following code's output it a list with the general category first, followed by more detailled category descriptions"""
         try:
-            category = tree.xpath('//*[@class="css-5m4t2m"]//a/text()')
+            category = tree.xpath('//*[@class="css-5m4t2m"]//a/text()')[0]
         except:
             category = ""
-
         # teaser
         try:
-            teaser = " ".join(
-                tree.xpath('//*[@class="css-1psf6fc"]/text()')
-            )
+            teaser = " ".join(tree.xpath('//*[@class="css-1psf6fc"]/text()'))
         except:
             teaser = ""
         # bulletpoints
         try:
-            bulletpoints = " ".join(
-                tree.xpath('//*[@class="css-13lgcsh"]//li/text()')
-            )
+            bulletpoints = " ".join(tree.xpath('//*[@class="css-13lgcsh"]//li/text()'))
         except:
             bulletpoints = ""
         # title1
         try:
-            title1 = tree.xpath(
-                '//*[@class="css-1keap3i"]/text()'
-            )
+            title1 = tree.xpath('//*[@class="css-1keap3i"]/text()')
         except:
             title1 = ""
         # title2
         try:
-            title2 = tree.xpath(
-                '//*[@class="css-1kuo4az"]/text()'
-            )
+            title2 = tree.xpath('//*[@class="css-1kuo4az"]/text()')
         except:
             title2 = ""
         title = ": ".join(title1 + title2)
-
         # text
         try:
             text = "".join(tree.xpath('//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/p/text()|//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/h3/text()'))
         except:
+            logger.warning("Text could not be accessed - most likely a premium article")
             text = ""
-         
+        text = text.replace("\xa0", "")
         # author
         try:
             author = tree.xpath('//*[@class="sz-article__byline css-141ob1d emhdic30"]//text()')
         except:
+            logger.warning("No author")
             author = ""
-
+        author = "".join(author).strip().replace(".css-viqvuv{border-bottom:1px solid #29293a;-webkit-text-decoration:none;text-decoration:none;-webkit-transition:border-bottom 150ms ease-in-out;transition:border-bottom 150ms ease-in-out;}.css-viqvuv:hover{border-bottom-color:transparent;}", "").replace("Von ", "").replace("Gastbeitrag von ", "").replace("Interview von ", "")
+        
         extractedinfo = {
             "category": category,
             "title": title,

--- a/inca/rssscrapers/sueddeutsche_scraper.py
+++ b/inca/rssscrapers/sueddeutsche_scraper.py
@@ -16,7 +16,7 @@ class diesueddeutsche(rss):
         self.doctype = "sueddeutschet politik (www)"
         self.rss_url = "https://rss.sueddeutsche.de/app/service/rss/alles/index.rss?output=rss"
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=4, day=7)
+        self.date = datetime.datetime(year=2020, month=4, day=8)
 
     def parsehtml(self, htmlsource):
         """
@@ -63,7 +63,7 @@ class diesueddeutsche(rss):
         title = title.replace("\xa0", "")
         # text
         try:
-            text = "".join(tree.xpath('//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/p/text()|//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/h3/text()'))
+            text = "".join(tree.xpath('//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/p/text()|//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/h3/text()|//*[@class="tickaroo-event-item-content-text"]//h2/text()|//*[@class="tickaroo-event-item-content-text"]//br/text()'))
         except:
             logger.warning("Text could not be accessed - most likely a premium article")
             text = ""

--- a/inca/rssscrapers/sueddeutsche_scraper.py
+++ b/inca/rssscrapers/sueddeutsche_scraper.py
@@ -49,6 +49,7 @@ class diesueddeutsche(rss):
             bulletpoints = " ".join(tree.xpath('//*[@class="css-13lgcsh"]//li/text()'))
         except:
             bulletpoints = ""
+        bulletpoints = bulletpoints.replace("\xa0", "")
         # title1
         try:
             title1 = tree.xpath('//*[@class="css-1keap3i"]/text()')

--- a/inca/rssscrapers/sueddeutsche_scraper.py
+++ b/inca/rssscrapers/sueddeutsche_scraper.py
@@ -60,6 +60,7 @@ class diesueddeutsche(rss):
         except:
             title2 = ""
         title = ": ".join(title1 + title2)
+        title = title.replace("\xa0", "")
         # text
         try:
             text = "".join(tree.xpath('//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/p/text()|//*[@class="sz-article__body css-uswvo e1lg1pmy0"]/h3/text()'))

--- a/inca/rssscrapers/sueddeutsche_scraper.py
+++ b/inca/rssscrapers/sueddeutsche_scraper.py
@@ -41,15 +41,10 @@ class diesueddeutsche(rss):
             category = ""
         # teaser
         try:
-            teaser = " ".join(tree.xpath('//*[@class="css-1psf6fc"]/text()'))
+            teaser = " ".join(tree.xpath('//*[@class="css-1psf6fc"]/text()|//*[@class="css-13lgcsh"]//li/text()'))
         except:
             teaser = ""
-        # bulletpoints
-        try:
-            bulletpoints = " ".join(tree.xpath('//*[@class="css-13lgcsh"]//li/text()'))
-        except:
-            bulletpoints = ""
-        bulletpoints = bulletpoints.replace("\xa0", "")
+        teaser = teaser.replace("\xa0", "")
         # title1
         try:
             title1 = tree.xpath('//*[@class="css-1keap3i"]/text()')
@@ -83,7 +78,6 @@ class diesueddeutsche(rss):
             "text": text,
             "teaser": teaser,
             "byline": author,
-            "bulletpoints": bulletpoints,
         }
 
         return extractedinfo

--- a/inca/rssscrapers/tagesspiegel_scraper.py
+++ b/inca/rssscrapers/tagesspiegel_scraper.py
@@ -28,7 +28,7 @@ class dertagesspiegel(rss):
             "http://www.tagesspiegel.de/contentexport/feed/wissen",
         ]
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=4, day=7)
+        self.date = datetime.datetime(year=2020, month=4, day=8)
 
     def parsehtml(self, htmlsource):
         """
@@ -72,7 +72,7 @@ class dertagesspiegel(rss):
             author = tree.xpath('//*[@class="ts-author"]//a/text()')
         except:
             author = ""
-        author = "".join(author).strip()
+        author = ", ".join(author).strip()
         # text
         try:
             text = "".join(tree.xpath('//*[@class="ts-article-content"]//p/text()'))

--- a/inca/rssscrapers/tagesspiegel_scraper.py
+++ b/inca/rssscrapers/tagesspiegel_scraper.py
@@ -28,7 +28,7 @@ class dertagesspiegel(rss):
             "http://www.tagesspiegel.de/contentexport/feed/wissen",
         ]
         self.version = ".1"
-        self.date = datetime.datetime(year=2020, month=3, day=29)
+        self.date = datetime.datetime(year=2020, month=4, day=7)
 
     def parsehtml(self, htmlsource):
         """
@@ -46,9 +46,7 @@ class dertagesspiegel(rss):
 
         # category
         try:
-            category = tree.xpath(
-                '//*[@class="ts-breadcrumb"]//*[@class="ts-inverse-link"]//text()'
-            )
+            category = tree.xpath('//*[@class="ts-breadcrumb"]//*[@class="ts-inverse-link"]//text()')[0]
         except:
             category = ""
 
@@ -63,7 +61,7 @@ class dertagesspiegel(rss):
             title2 = tree.xpath('//*[@class="ts-headline"]//text()')[0]
         except:
             title2 = ""
-        title = title1 + title2
+        title = title1 + ": " + title2
         # teaser
         try:
             teaser = tree.xpath('//*[@class="ts-intro"]//text()')[0].replace("\n", "")
@@ -71,14 +69,17 @@ class dertagesspiegel(rss):
             teaser = ""
         # author
         try:
-            author = tree.xpath('//*[@class="ts-author"]/a/text()')
+            author = tree.xpath('//*[@class="ts-author"]//a/text()')
         except:
             author = ""
+        author = "".join(author).strip()
         # text
         try:
             text = "".join(tree.xpath('//*[@class="ts-article-content"]//p/text()'))
         except:
+            logger.warning("Text could not be accessed - most likely a premium article")
             text = ""
+        text = text.replace("\xa0", "")
 
         extractedinfo = {
             "category": category,


### PR DESCRIPTION
The following scrapers are adjusted, working, and ready for production:

myinca.rssscrapers.diewelt(save=False), 
myinca.rssscrapers.aachenerzeitung(save=False), 
myinca.rssscrapers.rheinischepost(save=False),
myinca.rssscrapers.stuttgarterzeitung(save=False), 
myinca.rssscrapers.dertagesspiegel(save=False), 
myinca.rssscrapers.diesueddeutsche(save=False) 

these scrapers can be moved to 'master'

We did not include 'paywall_na = TRUE' as  sometimes there are also videos or even short news updates without body text as well. This also differs per newspaper. Die Welt, for example, has quite a lot of video content compared to some of the other newspapers. For the Stuttgarter Zeitung, their RSS feed also features a city blog that the text-scraping doesn't work for either (it only features local news for the city, so it's not relevant for my purposes anyway. But still...). So the way I see it using "paywall_na" =TRUE would be misleading in too many cases to be of value here.



